### PR TITLE
Add withCredentials to HTTP requests

### DIFF
--- a/src/app/services/api.js
+++ b/src/app/services/api.js
@@ -227,6 +227,7 @@
             return {
                 method: 'POST',
                 data  : request,
+                withCredentials: true,
                 // headers: {
                     // 'Content-Type': 'application/x-www-form-urlencoded'
                 // },
@@ -322,6 +323,7 @@
             let myInit={
                 mode: 'cors',
                 method: 'post',
+                credentials: 'include',
                 headers: {
                     "Content-type": "application/x-www-form-urlencoded; charset=UTF-8"
                 },
@@ -436,6 +438,7 @@
                     headers: {  'Content-Type': 'application/x-www-form-urlencoded'},
                     url: url,
                     cache: false,
+                    withCredentials: true,
                 };
 
                 if (connection.baseauth)


### PR DESCRIPTION
If accessing a Clickhouse server that is behind an authenticating proxy (e.g. https://github.com/bitly/oauth2_proxy) it is necessary to include the proxy cookies in the request, otherwise the proxy will serve an access denied login page instead of passing the request on to Clickhouse. For this to work and browsers to actually include the cookies the authenticating proxy must also correctly serve headers Access-Control-Allow-Credentials:true and and Access-Control-Allow-Origin (with a specific domain).

The attached change enables this by setting the appropriate flags on the $http objects and Fetch call. These should have no effect if no authenticating proxies are used since no cookies would be present (Clickhouse does not use sessions). I haven't included the build artifacts in this for clarity, but I am happy to include those if desired.