### PR TITLE
Add auto-connection with environment variables to Docker image.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,4 +14,4 @@ ADD ./build /var/www/html
 RUN rm $DEFAULT
 RUN mv default $DEFAULT
 
-CMD if [ ! -z "$PASSWORD" ]; then sh -c "echo -n '$USER:$(openssl passwd -crypt $PASSWORD)\n' >> /etc/nginx/.htpasswd" ; else mv -f $APP_HOME/default_no_pass $DEFAULT ; fi && ./start.sh
+CMD ./start.sh

--- a/docker/start.sh
+++ b/docker/start.sh
@@ -1,2 +1,33 @@
 #!/usr/bin/env bash
+if [ ! -z "$PASSWORD" ]; then
+  sh -c "echo -n '$USER:$(openssl passwd -crypt $PASSWORD)\n' >> /etc/nginx/.htpasswd"
+else
+  mv -f $APP_HOME/default_no_pass $DEFAULT
+fi
+CONN=""
+if [ ! -z "$CH_NAME" ]; then
+   CONN+="window.global_tabix_default_settings.name=\"${CH_NAME}\";"
+fi
+if [ ! -z "$CH_HOST" ]; then
+   CONN+="window.global_tabix_default_settings.host=\"${CH_HOST}\";"
+fi
+if [ ! -z "$CH_PASSWORD" ]; then
+   CONN+="window.global_tabix_default_settings.password=\"${CH_PASSWORD}\";"
+fi
+if [ ! -z "$CH_LOGIN" ]; then
+   CONN+="window.global_tabix_default_settings.login=\"${CH_LOGIN}\";"
+fi
+if [ ! -z "$CH_PARAMS" ]; then
+   CONN+="window.global_tabix_default_settings.params=\"${CH_PARAMS}\";"
+fi
+if [ ! -z "$CONN" ]; then
+  INDEX=$(cat /var/www/html/index.html)
+  # Insert the connection string at the start of index.html if it does not already exist.
+  if [[ $INDEX != *"window.global_tabix_default_settings"* ]]; then
+    CONN="<script>window.global_tabix_default_settings={};${CONN}</script>"
+    # Use simple bash replacement to avoid escaping complexity.
+    INDEX=${INDEX/<head>/<head>$CONN}
+    echo $INDEX > /var/www/html/index.html
+  fi
+fi
 nginx -g "daemon off;"

--- a/manual/docs/Install.md
+++ b/manual/docs/Install.md
@@ -88,3 +88,7 @@ Now you can access `tabix.ui` by the link http://localhost:8080.
 > **More security**: you can limit access to your `tabix.ui` application on the proxy level. 
 > Use `-e USER='myuser' -e PASSWORD='mypass'` parameters to restrict access only for specified user. 
 > For example, `docker run -d -p 8080:80 -e USER='myuser' -e PASSWORD='mypass' spoonest/clickhouse-tabix-web-client`
+
+> **Automatic connection**: you can automatically connect to a Clickhouse server by specifying
+> `CH_NAME`, `CH_HOST`, `CH_LOGIN`, `CH_PASSWORD` and/or `CH_PARAMS` environment variables.
+> For example, `docker run -d -p 8080:80 -e CH_NAME='myco' -e CH_HOST='clickhouse.myco.intranet:8123' spoonest/clickhouse-tabix-web-client`


### PR DESCRIPTION
This pull request will inject environment variables for the default connection (as described in #26) into index.html. All the variables are optional and it will not take any action if they are not provided.

I went with a simple and direct approach of just inserting these after the <head> tag - it would be slightly more elegant to have an (initially blank) config.js that is loaded, but that could be a bit more disruptive to non-docker users - this code could easily be adapted to use that if desired though.